### PR TITLE
feat(completions): add dynamic session name completion for zsh

### DIFF
--- a/zellij-utils/assets/completions/comp.zsh
+++ b/zellij-utils/assets/completions/comp.zsh
@@ -1,13 +1,31 @@
+# =============================================================================
+# Zellij ZSH Dynamic Session Completion
+# =============================================================================
+
+# Get list of active session names for completion
+_zellij_sessions() {
+    local -a sessions
+    sessions=("${(@f)$(zellij list-sessions --short --no-formatting 2>/dev/null)}")
+    sessions=(${sessions:#})  # Remove empty entries
+    if (( ${#sessions} )); then
+        _describe -t sessions 'zellij session' sessions
+    fi
+}
+
+# =============================================================================
+# Convenience functions
+# =============================================================================
+
 function zr () { zellij run --name "$*" -- zsh -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
 function zri () { zellij run --name "$*" --in-place -- zsh -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
 function zei () { zellij edit --in-place "$*";}
-function zpipe () { 
+function zpipe () {
   if [ -z "$1" ]; then
     zellij pipe;
-  else 
+  else
     zellij pipe -p $1;
   fi
 }

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -554,22 +554,67 @@ impl Setup {
             },
         };
         let mut out = std::io::stdout();
-        clap_complete::generate(shell, &mut CliArgs::command(), "zellij", &mut out);
-        // add shell dependent extra completion
-        match shell {
-            Shell::Bash => {
-                let _ = out.write_all(BASH_EXTRA_COMPLETION);
-            },
-            Shell::Elvish => {},
-            Shell::Fish => {
-                let _ = out.write_all(FISH_EXTRA_COMPLETION);
-            },
-            Shell::PowerShell => {},
-            Shell::Zsh => {
-                let _ = out.write_all(ZSH_EXTRA_COMPLETION);
-            },
-            _ => {},
-        };
+
+        // For zsh, we need to post-process the completion to add dynamic session completion
+        if shell == Shell::Zsh {
+            let mut completion_buf = Vec::new();
+            clap_complete::generate(shell, &mut CliArgs::command(), "zellij", &mut completion_buf);
+
+            // Convert to string for processing
+            let completion_str = String::from_utf8_lossy(&completion_buf);
+
+            // Inject _zellij_sessions completer for session-related arguments
+            // These replacements add our custom completer function to the appropriate arguments
+            let completion_str = completion_str
+                // attach command: session-name argument
+                .replace(
+                    "'::session-name -- Name of the session to attach to:'",
+                    "'::session-name -- Name of the session to attach to:_zellij_sessions'",
+                )
+                // watch command: session-name argument
+                .replace(
+                    "'::session-name -- Name of the session to watch:'",
+                    "'::session-name -- Name of the session to watch:_zellij_sessions'",
+                )
+                // kill-session and delete-session commands: target-session argument
+                .replace(
+                    "'::target-session -- Name of target session:'",
+                    "'::target-session -- Name of target session:_zellij_sessions'",
+                )
+                // action switch-session command: name argument
+                .replace(
+                    "':name -- Name of the session to switch to:'",
+                    "':name -- Name of the session to switch to:_zellij_sessions'",
+                )
+                // Remove 'options' and 'help' subcommands from attach - we only want session names
+                .replace(
+                    "_zellij__attach_commands() {\n    local commands; commands=(\n'options:Change the behaviour of zellij' \\\n'help:Print this message or the help of the given subcommand(s)' \\\n    )\n    _describe -t commands 'zellij attach commands' commands \"$@\"\n}",
+                    "_zellij__attach_commands() {\n    local commands; commands=()\n    _describe -t commands 'zellij attach commands' commands \"$@\"\n}",
+                )
+                // Add alias support: clap_complete doesn't generate case entries for aliases,
+                // so we modify the case patterns to include both the full command and its alias
+                .replace("(attach)\n", "(attach|a)\n")
+                .replace("(watch)\n", "(watch|w)\n")
+                .replace("(kill-session)\n", "(kill-session|k)\n")
+                .replace("(delete-session)\n", "(delete-session|d)\n");
+
+            let _ = out.write_all(completion_str.as_bytes());
+            let _ = out.write_all(ZSH_EXTRA_COMPLETION);
+        } else {
+            clap_complete::generate(shell, &mut CliArgs::command(), "zellij", &mut out);
+            // add shell dependent extra completion
+            match shell {
+                Shell::Bash => {
+                    let _ = out.write_all(BASH_EXTRA_COMPLETION);
+                },
+                Shell::Elvish => {},
+                Shell::Fish => {
+                    let _ = out.write_all(FISH_EXTRA_COMPLETION);
+                },
+                Shell::PowerShell => {},
+                _ => {},
+            };
+        }
     }
 
     fn generate_auto_start(shell: &str) {

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -558,7 +558,12 @@ impl Setup {
         // For zsh, we need to post-process the completion to add dynamic session completion
         if shell == Shell::Zsh {
             let mut completion_buf = Vec::new();
-            clap_complete::generate(shell, &mut CliArgs::command(), "zellij", &mut completion_buf);
+            clap_complete::generate(
+                shell,
+                &mut CliArgs::command(),
+                "zellij",
+                &mut completion_buf,
+            );
 
             // Convert to string for processing
             let completion_str = String::from_utf8_lossy(&completion_buf);


### PR DESCRIPTION
## Summary

Adds dynamic tab completion for zellij session names in zsh. When typing `zellij attach <TAB>`, `zellij kill-session <TAB>`, etc., active session names are now suggested dynamically.

**Rebased:** onto upstream `e9173cba` (v0.44.3 / `0.45.0-dev`). Clean rebase — upstream touched neither `setup.rs` nor `comp.zsh`. CI re-running after the rebase force-push.

- Intercepts zsh completion generation in `generate_completion()` to inject a custom `_zellij_sessions()` function
- The function calls `zellij ls --short --no-formatting` to get active sessions at completion time
- Hooks into subcommands that accept session names: `attach`, `kill-session`, `delete-session`, `switch-session`, `watch`

### Commits
1. `feat(completions): add dynamic session name completion for zsh`
2. `style: fix formatting in setup.rs`

## Files Changed
- `zellij-utils/src/setup.rs` — Modified `generate_completion()` to post-process zsh completions
- `zellij-utils/assets/completions/comp.zsh` — Updated generated completion with session name function

## Test plan
- [x] Formatting passes (`cargo xtask format`)
- [ ] CI re-running after rebase force-push (was green pre-rebase)
- [ ] Manual: Source the generated completion (`zellij setup --generate-completion zsh > _zellij && source _zellij`)
- [ ] Manual: `zellij attach <TAB>` shows active session names
- [ ] Manual: `zellij kill-session <TAB>` shows active session names
- [ ] Manual: Works with partial input (e.g., `zellij attach my<TAB>` completes `my-session`)
